### PR TITLE
Fix github depscan

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -2,9 +2,6 @@
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 
-[requires]
-python_version = "3.6"
-
 [packages]
 cytoolz = "*"
 ed25519 = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -611,13 +611,6 @@
             ],
             "version": "==0.610"
         },
-        "parso": {
-            "hashes": [
-                "sha256:cdef26e8adc10d589f3ec4eb444bd0a29f3f1eb6d72a4292ab8afcb9d68976a6",
-                "sha256:f0604a40b96e062b0fd99cf134cc2d5cdf66939d0902f8267d938b0d5b26707f"
-            ],
-            "version": "==0.2.1"
-        },
         "pexpect": {
             "hashes": [
                 "sha256:2a8e88259839571d1251d278476f3eec5db26deb73a70be5ed5dc5435e418aba",


### PR DESCRIPTION
We don't have to require explicit py3 version: the default version can be used instead.
According to "pipenv graph" parso is not one of our direct/indirect dependencies so it can be removed from the lockfile.

Note: properly updating lockfile requires "pipenv lock" which is currently broken on my machine due to pip API changes. Hence this is just a quick fix to avoid referring to outdated and potentially vulnerable version of a package we don't use anyway.