### PR TITLE
Drop platform-specific non-dependencies

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -477,14 +477,6 @@
         }
     },
     "develop": {
-        "appnope": {
-            "hashes": [
-                "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
-                "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
-            ],
-            "markers": "sys_platform == 'darwin'",
-            "version": "==0.1.0"
-        },
         "atomicwrites": {
             "hashes": [
                 "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585",

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -603,14 +603,6 @@
             ],
             "version": "==0.610"
         },
-        "pexpect": {
-            "hashes": [
-                "sha256:2a8e88259839571d1251d278476f3eec5db26deb73a70be5ed5dc5435e418aba",
-                "sha256:3fbd41d4caf27fa4a377bfd16fef87271099463e6fa73e92a52f92dfee5d425b"
-            ],
-            "markers": "sys_platform != 'win32'",
-            "version": "==4.6.0"
-        },
         "pickleshare": {
             "hashes": [
                 "sha256:84a9257227dfdd6fe1b4be1319096c20eb85ff1e82c7932f36efccfe1b09737b",


### PR DESCRIPTION
Neither appnope nor pexpect are used anywhere in the code or as (in)direct dependencies via "pipenv graph". Both, however, have platform-specific markers in pipfile.lock which unnecessary complicates further fixes. Let's just drop those.